### PR TITLE
Add /api/reports.php endpoint for security alerts and failed logins

### DIFF
--- a/generic_secrets.php
+++ b/generic_secrets.php
@@ -53,4 +53,9 @@ return [
     // Admin consolidated alerts are not affected by this setting.
     // Example: 'user1@yourdomain.com', 'user2@yourdomain.com'
     'DISABLED_USER_ALERTS' => [],
+
+    // --- API Configuration ---
+    // The Bearer token required to access the /api/reports.php endpoint.
+    // Set to a strong, random string. If left blank, API access is disabled.
+    'API_TOKEN' => 'your_secure_api_token_here',
 ];

--- a/public/api/reports.php
+++ b/public/api/reports.php
@@ -1,0 +1,119 @@
+<?php
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+// Load credentials from secrets.php
+$secretsFile = __DIR__ . '/../../secrets.php';
+if (!file_exists($secretsFile)) {
+    http_response_code(500);
+    echo json_encode(['error' => 'Server configuration missing.']);
+    exit;
+}
+$secrets = require $secretsFile;
+foreach ($secrets as $key => $value) {
+    $_ENV[$key] = $value;
+}
+
+header('Content-Type: application/json');
+
+// Get API Token from environment
+$apiToken = $_ENV['API_TOKEN'] ?? '';
+if (empty($apiToken)) {
+    http_response_code(403);
+    echo json_encode(['error' => 'API access is disabled.']);
+    exit;
+}
+
+// Check Authorization header
+$headers = getallheaders();
+$authHeader = $headers['Authorization'] ?? $_SERVER['HTTP_AUTHORIZATION'] ?? '';
+
+if (!preg_match('/Bearer\s(\S+)/', $authHeader, $matches) || !hash_equals($apiToken, $matches[1])) {
+    http_response_code(401);
+    echo json_encode(['error' => 'Unauthorized']);
+    exit;
+}
+
+use App\Database;
+
+try {
+    $db = Database::getInstance();
+
+    $alerts = [];
+
+    // 1. Impossible Travel Alerts
+    $sqlTravel = "
+        SELECT l.user_principal_name, l.login_time, l.ip_address, l.city, l.country, l.travel_speed_kph, e.sent_at as email_sent_at
+        FROM login_logs l
+        JOIN email_alerts e ON l.id = e.alert_log_id AND l.previous_log_id = e.compared_log_id
+        WHERE l.is_impossible_travel = 1
+        AND e.alert_type = 'impossible_travel'
+        AND e.sent_at >= NOW() - INTERVAL 1 DAY
+        ORDER BY l.login_time DESC
+    ";
+    $stmtTravel = $db->query($sqlTravel);
+    while ($row = $stmtTravel->fetch(\PDO::FETCH_ASSOC)) {
+        $row['alert_type'] = 'impossible_travel';
+        $alerts[] = $row;
+    }
+
+    // 2. Region Change Alerts
+    $sqlRegion = "
+        SELECT l.user_principal_name, l.login_time, l.ip_address, l.city, l.region, l.country, e.sent_at as email_sent_at
+        FROM login_logs l
+        JOIN email_alerts e ON l.id = e.alert_log_id AND l.previous_log_id = e.compared_log_id
+        WHERE l.is_region_change = 1
+        AND e.alert_type = 'region_change'
+        AND e.sent_at >= NOW() - INTERVAL 1 DAY
+        ORDER BY l.login_time DESC
+    ";
+    $stmtRegion = $db->query($sqlRegion);
+    while ($row = $stmtRegion->fetch(\PDO::FETCH_ASSOC)) {
+        $row['alert_type'] = 'region_change';
+        $alerts[] = $row;
+    }
+
+    // 3. Device Change Alerts
+    // Device changes always send an email according to documentation
+    $sqlDevice = "
+        SELECT user_principal_name, change_time as event_time, device_display_name, change_type
+        FROM auth_device_changes
+        WHERE change_time >= NOW() - INTERVAL 1 DAY
+        ORDER BY change_time DESC
+    ";
+    $stmtDevice = $db->query($sqlDevice);
+    while ($row = $stmtDevice->fetch(\PDO::FETCH_ASSOC)) {
+        $row['alert_type'] = 'device_change';
+        $row['email_sent_at'] = $row['event_time']; // Since it's sent concurrently
+        $alerts[] = $row;
+    }
+
+    // 4. Failed Login Counts (Last 24 hours)
+    $failedLogins = [];
+    $sqlFailed = "
+        SELECT user_principal_name, COUNT(*) as failed_count
+        FROM login_logs
+        WHERE login_time >= NOW() - INTERVAL 1 DAY
+        AND status LIKE 'Failure%'
+        GROUP BY user_principal_name
+        ORDER BY failed_count DESC
+    ";
+    $stmtFailed = $db->query($sqlFailed);
+    while ($row = $stmtFailed->fetch(\PDO::FETCH_ASSOC)) {
+        $failedLogins[] = [
+            'user_principal_name' => $row['user_principal_name'],
+            'failed_count' => (int)$row['failed_count']
+        ];
+    }
+
+    $response = [
+        'generated_at' => gmdate('Y-m-d\TH:i:s\Z'),
+        'alerts' => $alerts,
+        'failed_logins' => $failedLogins
+    ];
+
+    echo json_encode($response, JSON_PRETTY_PRINT);
+
+} catch (\Exception $e) {
+    http_response_code(500);
+    echo json_encode(['error' => 'Internal server error.']);
+}

--- a/public/index.php
+++ b/public/index.php
@@ -186,6 +186,25 @@ if ($auth->check()) {
             passthru(escapeshellcmd($phpPath . " " . $scriptPath));
             exit;
         }
+
+        if (isset($_POST['generate_api_token'])) {
+            $newToken = bin2hex(random_bytes(24));
+            $secretsContent = file_get_contents($secretsFile);
+
+            if (preg_match('/\'API_TOKEN\'\s*=>\s*\'[^\']*\'/', $secretsContent)) {
+                $secretsContent = preg_replace('/\'API_TOKEN\'\s*=>\s*\'[^\']*\'/', "'API_TOKEN' => '$newToken'", $secretsContent);
+            } else {
+                $secretsContent = preg_replace('/\];\s*$/', "    // --- API Configuration ---\n    'API_TOKEN' => '$newToken',\n];", $secretsContent);
+            }
+
+            if (file_put_contents($secretsFile, $secretsContent)) {
+                $_SESSION['info_message'] = "New API Token generated successfully.";
+            } else {
+                $_SESSION['info_message'] = "Error: Could not write to secrets.php. Check permissions.";
+            }
+            header('Location: ' . BASE_PATH);
+            exit;
+        }
     }
 
     if (isset($_GET['trigger']) && $_GET['trigger'] === 'background') {
@@ -250,6 +269,19 @@ if ($auth->check()) {
                 <?php endif; ?>
 
                 <div class="action-bar">
+                    <div style="background:#f1f5f9; padding: 8px 12px; border-radius: 4px; font-size: 0.9em; border: 1px solid #cbd5e1; margin-right: auto; display: flex; align-items: center; gap: 10px;">
+                        <strong>API Token:</strong>
+                        <?php if (!empty($_ENV['API_TOKEN'])): ?>
+                            <code style="background:#e2e8f0; padding: 2px 6px; border-radius: 3px; user-select: all;"><?= htmlspecialchars($_ENV['API_TOKEN']) ?></code>
+                        <?php else: ?>
+                            <span style="color: #64748b; font-style: italic;">Not generated</span>
+                        <?php endif; ?>
+                        <form method="POST" action="<?= BASE_PATH ?>" style="margin: 0; display: inline-block;">
+                            <button type="submit" name="generate_api_token" style="padding: 4px 8px; font-size: 0.85em; background: #3b82f6; border: none; color: white; border-radius: 3px; cursor: pointer;">
+                                <?= empty($_ENV['API_TOKEN']) ? 'Generate' : 'Regenerate' ?>
+                            </button>
+                        </form>
+                    </div>
                     <a href="<?= BASE_PATH ?>?trigger=background" class="action-button">Manually Trigger Sync</a>
                     <form method="POST" action="<?= BASE_PATH ?>" class="export-form">
                         <select name="export_type">


### PR DESCRIPTION
Add /api/reports.php endpoint for security alerts and failed logins

This implements an API endpoint that can be accessed with a Bearer token
to retrieve the last 24 hours of impossible speed, region changes, and
device changes alerts, as well as a summary of failed login counts per
user. It also adds a feature to the UI to generate and view the API token.

---
*PR created automatically by Jules for task [11860805973260882822](https://jules.google.com/task/11860805973260882822) started by @zeighy*